### PR TITLE
Use HTTPS where possible

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -19,7 +19,7 @@
     </a>
 
     <a href="https://github.com/Wildhoney/Legofy" target="_blank">
-        <img class="fork" src="http://aral.github.com/fork-me-on-github-retina-ribbons/left-grey@2x.png" alt="Fork me on GitHub.com" />
+        <img class="fork" src="https://aral.github.com/fork-me-on-github-retina-ribbons/left-grey@2x.png" alt="Fork me on GitHub.com" />
     </a>
 
 </body>


### PR DESCRIPTION
Sadly https://www.lego.com/en-gb returns `404 Not Found`. Would be good if there was an HTTPS LEGO website or a way to contact they to fix that.
