### PR TITLE
Remove deprecated `webkitImageSmoothingEnabled`

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -93,7 +93,6 @@ export function transform(img, { factor = DEFAULTS.FACTOR, blendMode = DEFAULTS.
 
         // Setup the pixelation of the source image on the canvas.
         context.mozImageSmoothingEnabled = false;
-        context.webkitImageSmoothingEnabled = false;
         context.imageSmoothingEnabled = false;
         context.drawImage(original, 0, 0, small.width, small.height);
         context.rect(0, 0, width, height);


### PR DESCRIPTION
![screen shot 2015-12-07 at 15 09 24](https://cloud.githubusercontent.com/assets/193238/11630320/d0281a06-9cf4-11e5-94bf-0beb62aa42a6.png)

I kept getting that warning in the console, so I figured I'd remove the offending line.

Thank you for all your work on an awesome module :)
